### PR TITLE
add run_constraints for jupyterlab, test against oldest suported

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,6 +3,8 @@ schema_version: 1
 
 context:
   version: 1.1.0
+  lab_min: "4.1.0"
+  lab_max: "5.0.0"
 
 package:
   name: ipylab
@@ -13,7 +15,7 @@ source:
   sha256: f39858a4d9ef6ecb82f8efeeb9f6b5a01a3a64d4f3c4f2a5fe2d58ae594de212
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
@@ -23,12 +25,14 @@ requirements:
     - hatch-jupyter-builder >=0.8.2
     - hatch-nodejs-version
     - hatchling >=1.5.0
-    - jupyterlab >=4.0.0,<5
+    - jupyterlab >=${{ lab_min }},<${{ lab_max }}
     - pip
     - python ${{ python_min }}.*
   run:
     - ipywidgets >=7.6.0,<9
     - python >=${{ python_min }}
+  run_constraints:
+    - jupyterlab >=${{ lab_min }},<${{ lab_max }}
 
 tests:
   - python:
@@ -39,7 +43,7 @@ tests:
         - 3.13.*
   - requirements:
       run:
-        - jupyterlab >=4.0.0,<5
+        - jupyterlab ${{ lab_min }}.*
         - python ${{ python_min }}.*
     script:
       - jupyter labextension list


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

References:
- continues #21 
- starts #19
  - > follow-on would be a repodata-patches PR which set all of them accurately
- proposed upstream fix at https://github.com/jtpio/ipylab/pull/159

Changes:
- [x] update bottom jupyterlab pin to `4.1.0`
- [x] add `run_constraint`
- [x] use oldest version in `jupyter labextension list` in test excursion

```
 │ ✔ Successfully updated the test environment
 │ Testing commands:
 │ JupyterLab v4.0.0
 │ $SRC_DIR_run_env/share/jupyter/labextensions
 │         jupyterlab_pygments v0.3.0 enabled OK (python, jupyterlab_pygments)
 │         ipylab v1.1.0 enabled  X (python, ipylab)
 │         @jupyter-widgets/jupyterlab-manager v5.0.15 enabled OK (python, jupyterlab_widgets)
 │ "ipylab@1.1.0" is not compatible with the current JupyterLab
 │ Conflicting Dependencies:
 │ JupyterLab              Extension      Package
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/application
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/apputils
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/mainmenu
 │ >=4.0.0 <4.1.0          >=4.1.0 <5.0.0 @jupyterlab/notebook
```  